### PR TITLE
Simulation Methods

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -15,14 +15,24 @@ class Agent:
 
     # Decide the next move based on the game state and the agent's chromosome
     # Returns the action to take, plus a number of chips if the action is a raise
-    def action(
-        self, game: TexasHoldEm, random: bool = False
-    ) -> Tuple[ActionType, Optional[int]]:
-        if random:
-            return random_agent(game)
-        else:
-            pass
+    def action(self, game: TexasHoldEm) -> Tuple[ActionType, Optional[int]]:
+        pass
 
     # Get the agent's underlying chromosome
     def get_chromosome(self) -> Chromosome:
         return self.chromosome
+
+
+# A child class that makes random moves, used for testing
+class RandomAgent(Agent):
+    def __init__(self, id):
+        # since random agents do not have a chromosome, they need an ID to be 
+        # differentiable from other random agents
+        self.id = id
+        pass
+
+    def action(self, game: TexasHoldEm) -> Tuple[ActionType, Optional[int]]:
+        return random_agent(game)
+
+    def get_chromosome(self) -> None:
+        return None

--- a/agent.py
+++ b/agent.py
@@ -2,6 +2,7 @@ from typing import Tuple, Optional
 
 from texasholdem.game.game import TexasHoldEm
 from texasholdem.game.action_type import ActionType
+from texasholdem.agents.basic import random_agent
 
 from chromosome import Chromosome
 
@@ -14,8 +15,13 @@ class Agent:
 
     # Decide the next move based on the game state and the agent's chromosome
     # Returns the action to take, plus a number of chips if the action is a raise
-    def action(self, game: TexasHoldEm) -> Tuple[ActionType, Optional[int]]:
-        pass
+    def action(
+        self, game: TexasHoldEm, random: bool = False
+    ) -> Tuple[ActionType, Optional[int]]:
+        if random:
+            return random_agent(game)
+        else:
+            pass
 
     # Get the agent's underlying chromosome
     def get_chromosome(self) -> Chromosome:

--- a/notebooks/game_test.ipynb
+++ b/notebooks/game_test.ipynb
@@ -9,21 +9,133 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
     "from texasholdem.game.game import TexasHoldEm\n",
     "from texasholdem.gui.text_gui import TextGUI\n",
     "from texasholdem.agents.basic import random_agent\n",
-    "import pprint\n",
-    "\n",
-    "game = TexasHoldEm(buyin=500, big_blind=5, small_blind=2, max_players=6)\n"
+    "import pprint\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{0: (5, -1, [1])}\n",
+      "{0: (10, -1, [1])}\n",
+      "{0: (236, -1, [0])}\n",
+      "{0: (5, -1, [0])}\n",
+      "{0: (293, -1, [1])}\n",
+      "{0: (5, -1, [0])}\n",
+      "{0: (444, -1, [1])}\n",
+      "{0: (954, -1, [1])}\n",
+      "{0: (20, -1, [0])}\n",
+      "{0: (5, -1, [0])}\n",
+      "{0: (29, -1, [0])}\n",
+      "{0: (5, -1, [0])}\n",
+      "{0: (5, -1, [1])}\n",
+      "{0: (5, -1, [0])}\n",
+      "{0: (49, -1, [0])}\n",
+      "{0: (122, 5317, [0]), 1: (549, -1, [1])}\n",
+      "{0: (5, -1, [1])}\n",
+      "{0: (377, -1, [1])}\n",
+      "{0: (76, -1, [0])}\n",
+      "{0: (310, 3602, [0]), 1: (455, -1, [1])}\n",
+      "{0: (10, -1, [1])}\n",
+      "{0: (10, -1, [1])}\n",
+      "{0: (5, -1, [1])}\n",
+      "{0: (10, -1, [1])}\n",
+      "{0: (10, -1, [0])}\n",
+      "{0: (5, -1, [0])}\n",
+      "{0: (600, 5607, [0]), 1: (271, -1, [1])}\n",
+      "{0: (800, 1600, [0]), 1: (128, -1, [0])}\n",
+      "{0: (800, 1600, [0]), 1: (128, -1, [0])}\n"
+     ]
+    }
+   ],
+   "source": [
+    "game = TexasHoldEm(buyin=500, big_blind=5, small_blind=0, max_players=2)\n",
+    "while game.is_game_running():\n",
+    "    game.start_hand()\n",
+    "    if game\n",
+    "    while game.is_hand_running():\n",
+    "        if game.current_player == 0:\n",
+    "            game.take_action(*random_agent(game))\n",
+    "        else:\n",
+    "            game.take_action(*random_agent(game))\n",
+    "    print(game.hand_history.settle.pot_winners)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "list(game.in_pot_iter(game.btn_loc + 1))[0]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{1: [Card(\"Ad\"), Card(\"Ah\")], 0: [Card(\"Ts\"), Card(\"6c\")]}"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "game."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "28"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "game.num_hands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
    "metadata": {},
    "outputs": [
     {
@@ -32,74 +144,63 @@
      "text": [
       "{'buyin': 500,\n",
       " 'big_blind': 5,\n",
-      " 'small_blind': 2,\n",
-      " 'max_players': 6,\n",
-      " 'players': [<texasholdem.game.game.Player object at 0x00000149DFB58710>,\n",
-      "             <texasholdem.game.game.Player object at 0x00000149DFB5A210>,\n",
-      "             <texasholdem.game.game.Player object at 0x00000149DFB59160>,\n",
-      "             <texasholdem.game.game.Player object at 0x00000149DFB58260>,\n",
-      "             <texasholdem.game.game.Player object at 0x00000149DFB58920>,\n",
-      "             <texasholdem.game.game.Player object at 0x00000149DFB58560>],\n",
-      " 'btn_loc': 3,\n",
-      " 'bb_loc': 5,\n",
-      " 'sb_loc': 4,\n",
-      " 'current_player': 2,\n",
-      " 'pots': [<texasholdem.game.game.Pot object at 0x00000149DFB5ABA0>],\n",
-      " '_deck': <texasholdem.card.deck.Deck object at 0x00000149DFB59460>,\n",
-      " 'board': [],\n",
-      " 'hands': {4: [Card(\"7s\"), Card(\"Qd\")],\n",
-      "           5: [Card(\"9h\"), Card(\"Qs\")],\n",
-      "           0: [Card(\"Jh\"), Card(\"Js\")],\n",
-      "           1: [Card(\"Kh\"), Card(\"2s\")],\n",
-      "           2: [Card(\"3s\"), Card(\"9s\")],\n",
-      "           3: [Card(\"As\"), Card(\"5c\")]},\n",
-      " 'last_raise': 268,\n",
+      " 'small_blind': 0,\n",
+      " 'max_players': 2,\n",
+      " 'players': [<texasholdem.game.game.Player object at 0x000001E934B21460>,\n",
+      "             <texasholdem.game.game.Player object at 0x000001E934B23260>],\n",
+      " 'btn_loc': 0,\n",
+      " 'bb_loc': 1,\n",
+      " 'sb_loc': 0,\n",
+      " 'current_player': 1,\n",
+      " 'pots': [<texasholdem.game.game.Pot object at 0x000001E934B230E0>,\n",
+      "          <texasholdem.game.game.Pot object at 0x000001E934B23020>],\n",
+      " '_deck': <texasholdem.card.deck.Deck object at 0x000001E934B22D50>,\n",
+      " 'board': [Card(\"Td\"), Card(\"9s\"), Card(\"Qh\"), Card(\"7d\"), Card(\"Kc\")],\n",
+      " 'hands': {1: [Card(\"Ad\"), Card(\"Ah\")], 0: [Card(\"Ts\"), Card(\"6c\")]},\n",
+      " 'last_raise': 448,\n",
       " 'raise_option': True,\n",
-      " 'num_hands': 1,\n",
-      " 'hand_phase': <HandPhase.PREFLOP: _HandPhase(new_cards=0, next_phase='FLOP')>,\n",
-      " 'game_state': <GameState.RUNNING: 1>,\n",
-      " '_handstate_handler': {<HandPhase.PREHAND: _HandPhase(new_cards=0, next_phase='PREFLOP')>: <bound method TexasHoldEm._prehand of <texasholdem.game.game.TexasHoldEm object at 0x00000149DFB58620>>,\n",
-      "                        <HandPhase.PREFLOP: _HandPhase(new_cards=0, next_phase='FLOP')>: <function TexasHoldEm.__init__.<locals>.<lambda> at 0x00000149DFA63EC0>,\n",
-      "                        <HandPhase.FLOP: _HandPhase(new_cards=3, next_phase='TURN')>: <function TexasHoldEm.__init__.<locals>.<lambda> at 0x00000149DFA639C0>,\n",
-      "                        <HandPhase.TURN: _HandPhase(new_cards=1, next_phase='RIVER')>: <function TexasHoldEm.__init__.<locals>.<lambda> at 0x00000149DFA62980>,\n",
-      "                        <HandPhase.RIVER: _HandPhase(new_cards=1, next_phase='SETTLE')>: <function TexasHoldEm.__init__.<locals>.<lambda> at 0x00000149DFF789A0>,\n",
-      "                        <HandPhase.SETTLE: _HandPhase(new_cards=0, next_phase='PREHAND')>: <bound method TexasHoldEm._settle of <texasholdem.game.game.TexasHoldEm object at 0x00000149DFB58620>>},\n",
-      " 'hand_history': History(prehand=PrehandHistory(btn_loc=3,\n",
+      " 'num_hands': 28,\n",
+      " 'hand_phase': <HandPhase.PREHAND: _HandPhase(new_cards=0, next_phase='PREFLOP')>,\n",
+      " 'game_state': <GameState.STOPPED: 2>,\n",
+      " '_handstate_handler': {<HandPhase.PREHAND: _HandPhase(new_cards=0, next_phase='PREFLOP')>: <bound method TexasHoldEm._prehand of <texasholdem.game.game.TexasHoldEm object at 0x000001E934972D80>>,\n",
+      "                        <HandPhase.PREFLOP: _HandPhase(new_cards=0, next_phase='FLOP')>: <function TexasHoldEm.__init__.<locals>.<lambda> at 0x000001E934F7AB60>,\n",
+      "                        <HandPhase.FLOP: _HandPhase(new_cards=3, next_phase='TURN')>: <function TexasHoldEm.__init__.<locals>.<lambda> at 0x000001E934F7AF20>,\n",
+      "                        <HandPhase.TURN: _HandPhase(new_cards=1, next_phase='RIVER')>: <function TexasHoldEm.__init__.<locals>.<lambda> at 0x000001E934F794E0>,\n",
+      "                        <HandPhase.RIVER: _HandPhase(new_cards=1, next_phase='SETTLE')>: <function TexasHoldEm.__init__.<locals>.<lambda> at 0x000001E934F78220>,\n",
+      "                        <HandPhase.SETTLE: _HandPhase(new_cards=0, next_phase='PREHAND')>: <bound method TexasHoldEm._settle of <texasholdem.game.game.TexasHoldEm object at 0x000001E934972D80>>},\n",
+      " 'hand_history': History(prehand=PrehandHistory(btn_loc=0,\n",
       "                                                big_blind=5,\n",
-      "                                                small_blind=2,\n",
-      "                                                player_chips={0: 500,\n",
-      "                                                              1: 500,\n",
-      "                                                              2: 500,\n",
-      "                                                              3: 500,\n",
-      "                                                              4: 500,\n",
-      "                                                              5: 500},\n",
-      "                                                player_cards={4: [Card(\"7s\"),\n",
-      "                                                                  Card(\"Qd\")],\n",
-      "                                                              5: [Card(\"9h\"),\n",
-      "                                                                  Card(\"Qs\")],\n",
-      "                                                              0: [Card(\"Jh\"),\n",
-      "                                                                  Card(\"Js\")],\n",
-      "                                                              1: [Card(\"Kh\"),\n",
-      "                                                                  Card(\"2s\")],\n",
-      "                                                              2: [Card(\"3s\"),\n",
-      "                                                                  Card(\"9s\")],\n",
-      "                                                              3: [Card(\"As\"),\n",
-      "                                                                  Card(\"5c\")]}),\n",
+      "                                                small_blind=0,\n",
+      "                                                player_chips={0: 156, 1: 844},\n",
+      "                                                player_cards={1: [Card(\"Ad\"),\n",
+      "                                                                  Card(\"Ah\")],\n",
+      "                                                              0: [Card(\"Ts\"),\n",
+      "                                                                  Card(\"6c\")]}),\n",
       "                         preflop=BettingRoundHistory(new_cards=[],\n",
       "                                                     actions=[PlayerAction(player_id=0,\n",
-      "                                                                           action_type=<ActionType.FOLD: 5>,\n",
-      "                                                                           total=None,\n",
-      "                                                                           value=None),\n",
+      "                                                                           action_type=<ActionType.RAISE: 1>,\n",
+      "                                                                           total=72,\n",
+      "                                                                           value=67),\n",
       "                                                              PlayerAction(player_id=1,\n",
       "                                                                           action_type=<ActionType.RAISE: 1>,\n",
-      "                                                                           total=273,\n",
-      "                                                                           value=268)]),\n",
-      "                         settle=None,\n",
+      "                                                                           total=520,\n",
+      "                                                                           value=448),\n",
+      "                                                              PlayerAction(player_id=0,\n",
+      "                                                                           action_type=<ActionType.CALL: 3>,\n",
+      "                                                                           total=None,\n",
+      "                                                                           value=None)]),\n",
+      "                         settle=SettleHistory(new_cards=[Card(\"Td\"),\n",
+      "                                                         Card(\"9s\"),\n",
+      "                                                         Card(\"Qh\"),\n",
+      "                                                         Card(\"7d\"),\n",
+      "                                                         Card(\"Kc\")],\n",
+      "                                              pot_winners={0: (312, 3327, [1]),\n",
+      "                                                           1: (364, -1, [1])}),\n",
       "                         flop=None,\n",
       "                         turn=None,\n",
       "                         river=None),\n",
-      " '_action': (<ActionType.RAISE: 1>, 273),\n",
-      " '_hand_gen': <generator object TexasHoldEm._hand_iter at 0x00000149E0156F60>}\n"
+      " '_action': (<ActionType.CALL: 3>, None),\n",
+      " '_hand_gen': <generator object TexasHoldEm._hand_iter at 0x000001E934F70930>}\n"
      ]
     }
    ],
@@ -109,33 +210,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "In the middle of a hand!",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[36], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[43mgame\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstart_hand\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[1;32mc:\\Users\\Chris\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\texasholdem\\game\\game.py:1065\u001b[0m, in \u001b[0;36mTexasHoldEm.start_hand\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m   1056\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[0;32m   1057\u001b[0m \u001b[38;5;124;03mStarts a new hand. Handles :obj:`~texasholdem.game.player_state.PlayerState.SKIP`,\u001b[39;00m\n\u001b[0;32m   1058\u001b[0m \u001b[38;5;124;03mnot enough chips, resetting pots, rotation and posting of blinds, dealing cards, etc.\u001b[39;00m\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m   1062\u001b[0m \n\u001b[0;32m   1063\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[0;32m   1064\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mis_hand_running():\n\u001b[1;32m-> 1065\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mIn the middle of a hand!\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m   1067\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhand_phase \u001b[38;5;241m=\u001b[39m HandPhase\u001b[38;5;241m.\u001b[39mPREHAND\n\u001b[0;32m   1068\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_handstate_handler[\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhand_phase]()\n",
-      "\u001b[1;31mValueError\u001b[0m: In the middle of a hand!"
-     ]
+     "data": {
+      "text/plain": [
+       "WindowsPath('C:/Users/Chris/src/ece470/chip-fumbler/notebooks/texas.pgn')"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
+   "source": [
+    "game.export_history()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "game.start_hand()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "game.take_action(*random_agent(game))"
+    "while game.take_action(*random_agent(game)):\n",
+    "    pass"
    ]
   }
  ],

--- a/notebooks/simulation_test.ipynb
+++ b/notebooks/simulation_test.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Hack to get access to files defined in the parent directory\n",
+    "current_dir = Path.cwd()\n",
+    "parent_dir = current_dir.parent\n",
+    "sys.path.append(str(parent_dir))\n",
+    "\n",
+    "from simulation import simulation_1v1, round_robin\n",
+    "from agent import Agent\n",
+    "from chromosome import Chromosome"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 35.714285714285715)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# single game test\n",
+    "c = Chromosome(0,0)\n",
+    "A1 = Agent(c)\n",
+    "A2 = Agent(c)\n",
+    "\n",
+    "simulation_1v1(A1, A2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# single game test\n",
+    "c = Chromosome(0,0)\n",
+    "A1 = Agent(c)\n",
+    "A2 = Agent(c)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/simulation_test.ipynb
+++ b/notebooks/simulation_test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,13 +16,13 @@
     "sys.path.append(str(parent_dir))\n",
     "\n",
     "from simulation import simulation_1v1, round_robin\n",
-    "from agent import Agent\n",
+    "from agent import Agent, RandomAgent\n",
     "from chromosome import Chromosome"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -30,18 +30,17 @@
      "output_type": "stream",
      "text": [
       "normal 1v1:\n",
-      "(0, 1)\n",
+      "(1, 1)\n",
       "\n",
       "1v1 using chips/hand as the scoring method:\n",
-      "(1, 31.25)\n"
+      "(1, 25.0)\n"
      ]
     }
    ],
    "source": [
     "# single game test\n",
-    "c = Chromosome(0,0)\n",
-    "A0 = Agent(c)\n",
-    "A1 = Agent(c)\n",
+    "A0 = RandomAgent(0)\n",
+    "A1 = RandomAgent(1)\n",
     "\n",
     "print(\"normal 1v1:\")\n",
     "print(simulation_1v1(A0, A1))\n",
@@ -54,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -62,24 +61,34 @@
      "output_type": "stream",
      "text": [
       "round robin tournament, scored by wins:\n",
-      "agent 0: 3\n",
-      "agent 1: -5\n",
-      "agent 2: 3\n",
-      "agent 3: -7\n",
-      "agent 4: 5\n",
+      "agent 0: -1\n",
+      "agent 1: -1\n",
+      "agent 2: 1\n",
+      "agent 3: -1\n",
+      "agent 4: -1\n",
       "agent 5: 3\n",
       "agent 6: -1\n",
-      "agent 7: -1\n",
+      "agent 7: 1\n",
       "\n",
       "round robin tournament, scored by chips per hand::\n",
-      "agent 0: -142.26190476190473\n",
-      "agent 1: 32.73809523809528\n",
-      "agent 2: -289.2857142857143\n",
-      "agent 3: 702.9761904761905\n",
-      "agent 4: -682.7586206896551\n",
-      "agent 5: 229.16666666666669\n",
-      "agent 6: 69.11027568922306\n",
-      "agent 7: 80.31501166709879\n",
+      "agent 0: -189.54173067076292\n",
+      "agent 1: -460.1495726495727\n",
+      "agent 2: 128.5027696318019\n",
+      "agent 3: 1020.4777145566619\n",
+      "agent 4: -500.00702878992354\n",
+      "agent 5: 53.165109744057105\n",
+      "agent 6: -73.33019833019833\n",
+      "agent 7: 20.882936507936506\n",
+      "\n",
+      "round robin tournament, where each agent plays every other agent 3 times:\n",
+      "agent 0: 9\n",
+      "agent 1: -3\n",
+      "agent 2: 3\n",
+      "agent 3: 1\n",
+      "agent 4: -3\n",
+      "agent 5: -3\n",
+      "agent 6: 5\n",
+      "agent 7: -9\n",
       "\n"
      ]
     }
@@ -90,8 +99,7 @@
     "        print(f\"agent {i}: {scores[agents[i]]}\")\n",
     "\n",
     "\n",
-    "c = Chromosome(0,0)\n",
-    "agents = [Agent(c) for i in range(8)]\n",
+    "agents = [RandomAgent(i) for i in range(8)]\n",
     "\n",
     "print(\"round robin tournament, scored by wins:\")\n",
     "scores = round_robin(agents)\n",
@@ -102,12 +110,16 @@
     "scores = round_robin(agents, scoring_method=\"chips per hand\")\n",
     "print_scores(scores=scores, agents=agents)\n",
     "print()\n",
-    "\n"
+    "\n",
+    "print(\"round robin tournament, where each agent plays every other agent 3 times:\")\n",
+    "scores = round_robin(agents, cycles=3)\n",
+    "print_scores(scores=scores, agents=agents)\n",
+    "print()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -121,7 +133,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:06<00:00, 14.38it/s]\n"
+      "100%|██████████| 100/100 [00:07<00:00, 14.12it/s]\n"
      ]
     }
    ],
@@ -129,7 +141,7 @@
     "print(\"speed test: seems to run around 14 tournaments per second on my computer\")\n",
     "from tqdm import tqdm\n",
     "for i in tqdm(range(100)):\n",
-    "    scores = round_robin(agents)"
+    "    round_robin(agents)"
    ]
   }
  ],

--- a/notebooks/simulation_test.ipynb
+++ b/notebooks/simulation_test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,18 +22,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "(1, 83.33333333333333)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "normal 1v1:\n",
+      "(0, 1)\n",
+      "\n",
+      "1v1 using chips/hand as the scoring method:\n",
+      "(1, 31.25)\n"
+     ]
     }
    ],
    "source": [
@@ -42,55 +43,94 @@
     "A0 = Agent(c)\n",
     "A1 = Agent(c)\n",
     "\n",
-    "simulation_1v1(A0, A1)"
+    "print(\"normal 1v1:\")\n",
+    "print(simulation_1v1(A0, A1))\n",
+    "print()\n",
+    "\n",
+    "\n",
+    "print(\"1v1 using chips/hand as the scoring method:\")\n",
+    "print(simulation_1v1(A0, A1, scoring_method=\"chips per hand\"))\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import itertools"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[(<agent.Agent at 0x1e17e732cf0>, 480.501012934393),\n",
-       " (<agent.Agent at 0x1e17e7aaa80>, 179.4172494172494),\n",
-       " (<agent.Agent at 0x1e17e7ab7a0>, 141.23931623931622),\n",
-       " (<agent.Agent at 0x1e17e7ab770>, 50.804668304668304),\n",
-       " (<agent.Agent at 0x1e17e7aab40>, -105.33910533910534),\n",
-       " (<agent.Agent at 0x1e17e7a8440>, -107.45853608756835),\n",
-       " (<agent.Agent at 0x1e17e732ae0>, -308.1531531531532),\n",
-       " (<agent.Agent at 0x1e17e731160>, -331.01145231580017)]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "round robin tournament, scored by wins:\n",
+      "agent 0: 3\n",
+      "agent 1: -5\n",
+      "agent 2: 3\n",
+      "agent 3: -7\n",
+      "agent 4: 5\n",
+      "agent 5: 3\n",
+      "agent 6: -1\n",
+      "agent 7: -1\n",
+      "\n",
+      "round robin tournament, scored by chips per hand::\n",
+      "agent 0: -142.26190476190473\n",
+      "agent 1: 32.73809523809528\n",
+      "agent 2: -289.2857142857143\n",
+      "agent 3: 702.9761904761905\n",
+      "agent 4: -682.7586206896551\n",
+      "agent 5: 229.16666666666669\n",
+      "agent 6: 69.11027568922306\n",
+      "agent 7: 80.31501166709879\n",
+      "\n"
+     ]
     }
    ],
    "source": [
-    "# tournament test\n",
+    "def print_scores(agents, scores):\n",
+    "    for i in range(len(agents)):\n",
+    "        print(f\"agent {i}: {scores[agents[i]]}\")\n",
+    "\n",
+    "\n",
     "c = Chromosome(0,0)\n",
     "agents = [Agent(c) for i in range(8)]\n",
-    "scores = round_robin(agents)\n",
     "\n",
-    "display(scores)"
+    "print(\"round robin tournament, scored by wins:\")\n",
+    "scores = round_robin(agents)\n",
+    "print_scores(scores=scores, agents=agents)\n",
+    "print()\n",
+    "\n",
+    "print(\"round robin tournament, scored by chips per hand::\")\n",
+    "scores = round_robin(agents, scoring_method=\"chips per hand\")\n",
+    "print_scores(scores=scores, agents=agents)\n",
+    "print()\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "speed test: seems to run around 14 tournaments per second on my computer\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:06<00:00, 14.38it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"speed test: seems to run around 14 tournaments per second on my computer\")\n",
+    "from tqdm import tqdm\n",
+    "for i in tqdm(range(100)):\n",
+    "    scores = round_robin(agents)"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/simulation_test.ipynb
+++ b/notebooks/simulation_test.ipynb
@@ -22,16 +22,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(1, 35.714285714285715)"
+       "(1, 83.33333333333333)"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -39,10 +39,50 @@
    "source": [
     "# single game test\n",
     "c = Chromosome(0,0)\n",
+    "A0 = Agent(c)\n",
     "A1 = Agent(c)\n",
-    "A2 = Agent(c)\n",
     "\n",
-    "simulation_1v1(A1, A2)"
+    "simulation_1v1(A0, A1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import itertools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(<agent.Agent at 0x1e17e732cf0>, 480.501012934393),\n",
+       " (<agent.Agent at 0x1e17e7aaa80>, 179.4172494172494),\n",
+       " (<agent.Agent at 0x1e17e7ab7a0>, 141.23931623931622),\n",
+       " (<agent.Agent at 0x1e17e7ab770>, 50.804668304668304),\n",
+       " (<agent.Agent at 0x1e17e7aab40>, -105.33910533910534),\n",
+       " (<agent.Agent at 0x1e17e7a8440>, -107.45853608756835),\n",
+       " (<agent.Agent at 0x1e17e732ae0>, -308.1531531531532),\n",
+       " (<agent.Agent at 0x1e17e731160>, -331.01145231580017)]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# tournament test\n",
+    "c = Chromosome(0,0)\n",
+    "agents = [Agent(c) for i in range(8)]\n",
+    "scores = round_robin(agents)\n",
+    "\n",
+    "display(scores)"
    ]
   },
   {
@@ -50,12 +90,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# single game test\n",
-    "c = Chromosome(0,0)\n",
-    "A1 = Agent(c)\n",
-    "A2 = Agent(c)"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/simulation.py
+++ b/simulation.py
@@ -1,7 +1,9 @@
 # Simulate a game with multiple agents, will make use of texasholdem game object
 #
+import itertools
 from typing import Tuple
 from texasholdem.game.game import TexasHoldEm
+
 from agent import Agent
 
 
@@ -57,3 +59,22 @@ def round_robin(agents: list[Agent]) -> dict[Agent, float]:
     Returns:
         a dict containing a score for each agent.
     """
+
+    # initialize a dict to store agent scores in 
+    scores = {agent: 0 for agent in agents}
+
+    # generate all possible agent pairs
+    agent_pairs = list(itertools.combinations(agents, 2))
+
+    for (A0, A1) in agent_pairs:
+        (winner, score) = simulation_1v1(A0, A1)
+        if winner == 0:
+            scores[A0] += score
+            scores[A1] -= score
+        else:
+            scores[A0] -= score
+            scores[A1] += score
+
+    # finally, sort scores in descending order
+    sorted_scores = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+    return sorted_scores

--- a/simulation.py
+++ b/simulation.py
@@ -58,9 +58,9 @@ def simulation_1v1(
         game.start_hand()
         while game.is_hand_running():
             if game.current_player == 0:
-                game.take_action(*A0.action(game, random=True))
+                game.take_action(*A0.action(game))
             else:
-                game.take_action(*A1.action(game, random=True))
+                game.take_action(*A1.action(game))
         if game_log:
             game.export_history("./pgns")  # save history
 
@@ -72,12 +72,14 @@ def simulation_1v1(
 
 
 def round_robin(
-    agents: list[Agent], scoring_method: str = "wins"
+    agents: list[Agent], cycles: int = 1, scoring_method: str = "wins"
 ) -> dict[Agent, float]:
     """Runs a round-robin tournament between a list of agents.
 
     Args:
         agents: a list of agents to enter into the tournament
+        cycles: how many matches each agent plays against every other agent
+        scoring_method: a string specifying how game scores are determined.
 
     Returns:
         a dict containing a score for each agent.
@@ -89,13 +91,14 @@ def round_robin(
     # generate all possible agent pairs
     agent_pairs = list(itertools.combinations(agents, 2))
 
-    for A0, A1 in agent_pairs:
-        (winner, score) = simulation_1v1(A0, A1, scoring_method=scoring_method)
-        if winner == 0:
-            scores[A0] += score
-            scores[A1] -= score
-        else:
-            scores[A0] -= score
-            scores[A1] += score
+    for _ in range(cycles):
+        for A0, A1 in agent_pairs:
+            (winner, score) = simulation_1v1(A0, A1, scoring_method=scoring_method)
+            if winner == 0:
+                scores[A0] += score
+                scores[A1] -= score
+            else:
+                scores[A0] -= score
+                scores[A1] += score
 
     return scores

--- a/simulation.py
+++ b/simulation.py
@@ -5,19 +5,47 @@ from texasholdem.game.game import TexasHoldEm
 from agent import Agent
 
 
-def simulation_1v1(A1: Agent, A2: Agent) -> Tuple[bool, float]:
+# define some constants for setting up the game:
+BUY_IN = 500
+BIG_BLIND = 5
+SMALL_BLIND = 0
+MAX_PLAYERS = 2
+
+
+def simulation_1v1(A0: Agent, A1: Agent, game_log: bool = False) -> Tuple[int, float]:
     """Runs a 1v1 simulation between two agents
 
     Args:
         A1: Agent 1
         A2: Agent 2
+        game_log: if true, generate a game log
 
     Returns:
-        A tuple containing: A bool indicating if A1 won, then a float indicating the
+        A tuple containing: the winner, then a float indicating the
         winner's average chips gained / hand
 
     """
-    pass
+    game = TexasHoldEm(
+        buyin=BUY_IN,
+        big_blind=BIG_BLIND,
+        small_blind=SMALL_BLIND,
+        max_players=MAX_PLAYERS,
+    )
+    while game.is_game_running():
+        game.start_hand()
+        while game.is_hand_running():
+            if game.current_player == 0:
+                game.take_action(*A0.action(game, random=True))
+            else:
+                game.take_action(*A1.action(game, random=True))
+        if game_log:
+            game.export_history("./pgns")  # save history
+
+    # When we arrive here, the game is over.
+    # We can determine who won by checking the active players in the pot:
+    winner = list(game.in_pot_iter(game.btn_loc + 1))[0]
+    chips_per_hand = BUY_IN / game.num_hands
+    return(winner, chips_per_hand)
 
 
 def round_robin(agents: list[Agent]) -> dict[Agent, float]:
@@ -29,4 +57,3 @@ def round_robin(agents: list[Agent]) -> dict[Agent, float]:
     Returns:
         a dict containing a score for each agent.
     """
-    pass


### PR DESCRIPTION
Added simulation functionality, which includes 3 main functions:

- simulation_1v1: runs a 1v1 game between two agents
- scoring: decides how game scores are determined. Choose between win based or chips per hand based scoring.
- round robin: implements a round robin tournament between a list of agents and aggregates the scores.

The file notebooks\simulation_test.ipynb provides examples of how these can be used. To test the simulations, a RandomAgent class was also made which makes random moves. 

PS: Notebooks are pretty unreadable in GitHub diffs. If you want to have a look at the notebook, do it from the simulation branch in vscode.